### PR TITLE
emit .file and .loc assembler derectives

### DIFF
--- a/codegen.go
+++ b/codegen.go
@@ -176,6 +176,8 @@ func (c *codeWriter) gen(node *Node) (err error) {
 		return
 	}
 
+	c.println("	.loc 1 %d", node.Tok.LineNo)
+
 	switch node.Kind {
 	case ND_NULL:
 		return

--- a/main.go
+++ b/main.go
@@ -76,6 +76,7 @@ func compile(arg string, w io.Writer) error {
 	// }
 	// }
 
+	fmt.Fprintf(w, ".file 1 \"%s\"\n", filename)
 	return codegen(w, prog) // make the asm code, down on the AST
 }
 


### PR DESCRIPTION
With these directives, gdb can print out an error location when a compiled program crashes.