### PR TITLE
Fix dereference type handling

### DIFF
--- a/type.go
+++ b/type.go
@@ -401,7 +401,7 @@ func (e *errWriter) visit(node *Node) {
 			return
 		}
 
-		node.Ty = node.Lhs.Ty.Base
+		node.Ty = copyType(node.Lhs.Ty.Base)
 		return
 	case ND_STMT_EXPR:
 		if node.Body != nil {


### PR DESCRIPTION
## Summary
- avoid mutating underlying slice type when dereferencing

## Testing
- `make build`
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_686266de28f0832a97cdc083c999bb9a